### PR TITLE
Allow (onhover) hidden header to show when Search box focused

### DIFF
--- a/content-scripts/extension-context/init.js
+++ b/content-scripts/extension-context/init.js
@@ -29,6 +29,7 @@ function bodyReady() {
 	if (extension.ready && extension.domReady) {
 		extension.features.addScrollToTop();
 		extension.features.font();
+		extension.features.showHeaderOnSearch();
 	}
 }
 

--- a/content-scripts/extension-context/youtube-features/general/general.js
+++ b/content-scripts/extension-context/youtube-features/general/general.js
@@ -551,3 +551,28 @@ extension.features.thumbnailsQuality = function (anything) {
 		}
 	}
 };
+
+/*--------------------------------------------------------------
+# SHOW HEADER ON "SEARCH"
+--------------------------------------------------------------*/
+
+extension.features.showHeaderOnSearch = function (event) {
+	var search = document.querySelector('input#search');
+	if (search) {
+
+		var headerPos = document.documentElement.getAttribute('it-header-position');
+		document.documentElement.setAttribute('it-header-position-original', headerPos);
+		if (headerPos !== 'normal' && headerPos !== 'static') {
+
+			search.addEventListener('focusin', function (e) {
+				document.documentElement.setAttribute('it-header-position', 'normal');
+			});
+
+			search.addEventListener('focusout', function (e) {
+				var origHeaderPos = document.documentElement.getAttribute('it-header-position-original');
+				document.documentElement.setAttribute('it-header-position', origHeaderPos);
+			});
+
+		}
+	}
+};

--- a/content-scripts/website-context/youtube-features/shortcuts.js
+++ b/content-scripts/website-context/youtube-features/shortcuts.js
@@ -538,7 +538,7 @@ ImprovedTube.shortcutResetPlaybackSpeed = function () {
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcutGoToSearchBox = function () {
-	var search = document.querySelector('#search');
+	var search = document.querySelector('input#search');
 
 	if (search) {
 		search.focus();


### PR DESCRIPTION
When the header appearance is not normal/static, this change allows the header to display (as if hovered) when the search box is opened (such as from a hotkey `/`), and the header returns to its original state once the user leaves the search input. Includes patch required for custom search shortcuts to work. 

Resolves #884 