### PR TITLE
fix Like+Dislike button shortcuts

### DIFF
--- a/content-scripts/website-context/youtube-features/shortcuts.js
+++ b/content-scripts/website-context/youtube-features/shortcuts.js
@@ -575,7 +575,7 @@ ImprovedTube.shortcutActivateCaptions = function () {
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcutLike = function () {
-	var like = (document.querySelectorAll('#menu #top-level-buttons-computed ytd-toggle-button-renderer')[0]);
+	var like = (document.querySelectorAll('#menu #top-level-buttons-computed ytd-toggle-button-renderer button')[0]);
 
 	if (like) {
 		like.click();

--- a/content-scripts/website-context/youtube-features/shortcuts.js
+++ b/content-scripts/website-context/youtube-features/shortcuts.js
@@ -588,7 +588,7 @@ ImprovedTube.shortcutLike = function () {
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcutDislike = function () {
-	var like = (document.querySelectorAll('#menu #top-level-buttons-computed ytd-toggle-button-renderer')[1]);
+	var like = (document.querySelectorAll('#menu #top-level-buttons-computed ytd-toggle-button-renderer button')[1]);
 
 	if (like) {
 		like.click();


### PR DESCRIPTION
This fixes the Like and Dislike shortcuts by accessing the button object rather than the higher level ytd tag.

Resolves #1525