### PR TITLE
Force speed but not for music

### DIFF
--- a/_locales/am/messages.json
+++ b/_locales/am/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -389,6 +389,9 @@
     "forcedPlaybackSpeed": {
         "message": "تثبيت سرعة التشغيل"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "فرض وضع المسرح"
     },

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/bn/messages.json
+++ b/_locales/bn/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "জোর করে প্লেব্যাক গতি"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "জোর করে থিয়েটার মোড"
     },

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "erzwungene Abspielgeschwindigkeit"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Kinomodus erzwingen"
     },

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Υποχρεωτική ταχύτητα αναπαραγωγής"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Υποχρεωτική λειτουργία κινηματογράφου"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -401,6 +401,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -383,6 +383,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/en_US/messages.json
+++ b/_locales/en_US/messages.json
@@ -383,6 +383,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forzar velocidad de reproducción"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forzar modo teatro"
     },

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -383,6 +383,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forzar velocidad de reproducción"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forzar modo teatro"
     },

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/fil/messages.json
+++ b/_locales/fil/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Vitesse de lecture forcée"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forcer le mode théâtre"
     },

--- a/_locales/gu/messages.json
+++ b/_locales/gu/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -383,6 +383,9 @@
     "forcedPlaybackSpeed": {
         "message": "जबरन पार्श्व गति"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "जबरन थिएटर मोड"
     },

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Prisiljena brzina reprodukcije"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Prisiljen kazališni način"
     },

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Paksa kecepatan pemutaran"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Paksa mode teater"
     },

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Velocità di riproduzione forzata"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Modalità cinema forzata"
     },

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "再生速度を指定する"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "シアターモードにする"
     },

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "되감기 속도 강제설정"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "강제 영화관 모드"
     },

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/ml/messages.json
+++ b/_locales/ml/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/mr/messages.json
+++ b/_locales/mr/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/ms/messages.json
+++ b/_locales/ms/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/nb_NO/messages.json
+++ b/_locales/nb_NO/messages.json
@@ -383,6 +383,9 @@
     "forcedPlaybackSpeed": {
         "message": "Tvungen avspillingshastighet"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Tvunget teater-modus"
     },

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forceer afspeelsnelheid"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forceer Theatermodus"
     },

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Tvungen avspillingshastighet"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Tvunget teater-modus"
     },

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Wymuś prędkość odtwarzania"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Wymuś tryb kinowy"
     },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": " Velocidade do reprodução forçado"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Modo teatro forçado"
     },

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forçar velocidade de leitura"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forçar modo de cinema"
     },

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Viteză de playback forțată"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Modul teatru forțat"
     },

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -389,6 +389,9 @@
     "forcedPlaybackSpeed": {
         "message": "Принудительная скорость воспроизведения"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Принудительно переходить в режим кино"
     },

--- a/_locales/si/messages.json
+++ b/_locales/si/messages.json
@@ -383,6 +383,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Vynútená rýchlosť prehrávania"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Vynútený divadelný režim"
     },

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/sw/messages.json
+++ b/_locales/sw/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/ta/messages.json
+++ b/_locales/ta/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/te/messages.json
+++ b/_locales/te/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theater mode"
     },

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Oynatma hızını uygulamaya zorla"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Sinema modunu zorla"
     },

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Forced playback speed"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Forced theatre mode"
     },

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "Tốc độ phát lại bắt buộc"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "Bắt buộc chế độ rạp hát"
     },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "强制设置播放速度"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "强制设置剧场模式"
     },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -386,6 +386,9 @@
     "forcedPlaybackSpeed": {
         "message": "強制播放速度"
     },
+    "forcedPlaybackSpeedMusic": {
+        "message": "Force playback speed for music"
+    },
     "forcedTheaterMode": {
         "message": "強制劇院模式"
     },

--- a/content-scripts/extension-context/init.js
+++ b/content-scripts/extension-context/init.js
@@ -29,6 +29,7 @@ function bodyReady() {
 	if (extension.ready && extension.domReady) {
 		extension.features.addScrollToTop();
 		extension.features.font();
+		extension.features.showHeaderOnSearch();
 	}
 }
 

--- a/content-scripts/extension-context/youtube-features/general/general.js
+++ b/content-scripts/extension-context/youtube-features/general/general.js
@@ -551,3 +551,28 @@ extension.features.thumbnailsQuality = function (anything) {
 		}
 	}
 };
+
+/*--------------------------------------------------------------
+# SHOW HEADER ON "SEARCH"
+--------------------------------------------------------------*/
+
+extension.features.showHeaderOnSearch = function (event) {
+	var search = document.querySelector('input#search');
+	if (search) {
+
+		var headerPos = document.documentElement.getAttribute('it-header-position');
+		document.documentElement.setAttribute('it-header-position-original', headerPos);
+		if (headerPos !== 'normal' && headerPos !== 'static') {
+
+			search.addEventListener('focusin', function (e) {
+				document.documentElement.setAttribute('it-header-position', 'normal');
+			});
+
+			search.addEventListener('focusout', function (e) {
+				var origHeaderPos = document.documentElement.getAttribute('it-header-position-original');
+				document.documentElement.setAttribute('it-header-position', origHeaderPos);
+			});
+
+		}
+	}
+};

--- a/content-scripts/website-context/youtube-features/player.js
+++ b/content-scripts/website-context/youtube-features/player.js
@@ -62,20 +62,32 @@ ImprovedTube.playerAutopauseWhenSwitchingTabs = function () {
 ImprovedTube.playerPlaybackSpeed = function (change) {
 	var player = this.elements.player,
 		video = player.querySelector('video'),
-		option = this.storage.player_playback_speed;
+		option = this.storage.player_playback_speed,
+		tries = 0;
+	const intervalMs = 100,
+		maxIntervalMs = 5000;
 
 	if (this.isset(option) === false) {
 		option = 1;
 	}
 
-	if (this.storage.player_forced_playback_speed === true) {
-		if (location.href.indexOf('music') === -1 && player.getVideoData().isLive === false) {
-			player.setPlaybackRate(Number(option));
-			video.playbackRate = Number(option);
-		} else {
-			player.setPlaybackRate(1);
+	var waitForDescInterval = setInterval(() => {
+		if (document.querySelector('div#description') || (++tries * intervalMs >= maxIntervalMs)) {
+			clearInterval(waitForDescInterval);
 		}
-	}
+
+		if (this.storage.player_forced_playback_speed === true) {
+			if (player.getVideoData().isLive === false &&
+				(this.storage.player_force_speed_on_music === true ||
+					(location.href.indexOf('music') === -1 && document.querySelector('h3#title')?.innerText !== 'Music')
+			)) {
+				player.setPlaybackRate(Number(option));
+				video.playbackRate = Number(option);
+			} else {
+				player.setPlaybackRate(1);
+			}
+		}
+	}, intervalMs);
 };
 
 

--- a/content-scripts/website-context/youtube-features/shortcuts.js
+++ b/content-scripts/website-context/youtube-features/shortcuts.js
@@ -538,7 +538,7 @@ ImprovedTube.shortcutResetPlaybackSpeed = function () {
 ------------------------------------------------------------------------------*/
 
 ImprovedTube.shortcutGoToSearchBox = function () {
-	var search = document.querySelector('#search');
+	var search = document.querySelector('input#search');
 
 	if (search) {
 		search.focus();

--- a/options-page/skeleton-parts/player.js
+++ b/options-page/skeleton-parts/player.js
@@ -109,6 +109,11 @@ extension.skeleton.main.layers.section.player.on.click = {
 			text: 'forcedPlaybackSpeed',
 			id: 'forced-playback-speed'
 		},
+		player_force_speed_on_music: {
+			component: 'switch',
+			text: 'forcedPlaybackSpeedMusic',
+			id: 'forced-playback-speed-music'
+		},
 		player_playback_speed: {
 			component: 'slider',
 			text: 'playbackSpeed',

--- a/options-page/styles/player.css
+++ b/options-page/styles/player.css
@@ -3,6 +3,7 @@
 --------------------------------------------------------------*/
 
 #forced-volume:not([data-value='true']) + .satus-slider,
-#forced-playback-speed:not([data-value='true']) + .satus-slider {
+#forced-playback-speed:not([data-value='true']) + .satus-switch,
+#forced-playback-speed:not([data-value='true']) + .satus-switch + .satus-slider {
 	display: none;
 }


### PR DESCRIPTION
Adds an option under Player->Forced Playback Speed (when enabled) to `Force playback speed for music`, defaults off so that if user does force an alternate playback speed, it doesn't apply to music.

Improved the music detection by checking the description (and in some cases the description doesn't load, so interval runs until it exists but maxes out at 5 secs)

I don't know the other languages so I used English in all the locale files for consistency.

Resolves #1538