### PR TITLE
Fixed ratio bar not showing.

### DIFF
--- a/content-scripts/extension-context/youtube-features/appearance/details/details.css
+++ b/content-scripts/extension-context/youtube-features/appearance/details/details.css
@@ -199,8 +199,8 @@ html[it-hide-more-button='true'] #menu yt-button-shape#button-shape {
 
 /* html[it-details-old-style=true]  */
 .ytd-watch-flexy #info-contents, .ytd-watch-flexy #meta-contents { display: block !important; } 
-#below.ytd-watch-flexy { top:-20px; }
-
+ytd-menu-renderer[has-flexible-items] { overflow-y: unset !important; }
+ytd-video-primary-info-renderer { padding-bottom: 14px !important; }
 
 html[it-description=hidden] ytd-video-secondary-info-renderer ytd-expander.ytd-video-secondary-info-renderer,
 html[it-description=hidden] div#action-panel-details,


### PR DESCRIPTION
`The overflow-y: unset !important;` property tells the browser to unset the vertical overflow property of this element, which means that content will not be hidden if it exceeds the height of the element.

[#1611](https://github.com/code-for-charity/ImprovedTube-for-YouTube/issues/1611)
[Anarios/return-youtube-dislike/issues/875](https://github.com/Anarios/return-youtube-dislike/issues/875)

![chrome_eTBs34ePw2](https://user-images.githubusercontent.com/64634605/225527870-31dd3ce8-86dd-4645-b69b-09efc4e17cbd.png)


![msedge_YN8ZvLzMqf](https://user-images.githubusercontent.com/64634605/225527130-55c25521-6786-4bc2-9264-435a058bcd5e.png)